### PR TITLE
Fix campaign iteration variable in fetch_inventory

### DIFF
--- a/core.py
+++ b/core.py
@@ -511,7 +511,7 @@ class AccountWorker:
             self.log(f"Получено {len(progress_data)} кампаний из Inventory")
             
             final_campaigns = []
-            for campaign in all_campaigns_
+            for campaign in all_campaigns_data:
                 campaign_id = campaign.get('id')
                 if campaign_id and campaign_id in progress_data:
                     self.log(f"Объединение данных для кампании {campaign_id}")


### PR DESCRIPTION
## Summary
- use `all_campaigns_data` when iterating campaigns in `fetch_inventory`

## Testing
- `python -m py_compile core.py`


------
https://chatgpt.com/codex/tasks/task_e_68aef3c558ac832e86b48de049dc9419