### PR TITLE
Wrap video-edge regex in capturing group

### DIFF
--- a/core.py
+++ b/core.py
@@ -235,7 +235,7 @@ class Channel:
         # Попробуем несколько паттернов
         patterns = [
             r'"spade_?url":\s*"([^"]+)"',
-            r'https://video-edge-[^\s"<>]+\.ts(?:\?[^\s"<>"]+)?'
+            r'(https://video-edge-[^\s"<>]+\.ts(?:\?[^\s"<>"]+)?)'
         ]
         
         for pattern in patterns:


### PR DESCRIPTION
## Summary
- Capture video-edge URL in regex so match.group(1) returns the URL

## Testing
- `python -m py_compile core.py`
- Manual regex test ensuring group capture works


------
https://chatgpt.com/codex/tasks/task_e_68aef549a370832eb4b36af5edbdc067