### PR TITLE
Read optional headers from config

### DIFF
--- a/get_headers.py
+++ b/get_headers.py
@@ -12,12 +12,14 @@ async def main():
                 all_headers = request.headers
                 client_integrity = all_headers.get("client-integrity")
                 client_version = all_headers.get("client-version")
-                if client_integrity and client_version and not headers_found.done():
+                device_id = all_headers.get("x-device-id")
+                if client_integrity and client_version and device_id and not headers_found.done():
                     print("\n✓ УСПЕХ! Необходимые заголовки перехвачены!")
                     print("Теперь вы можете закрыть и браузер, и этот скрипт (Ctrl+C).")
                     headers_found.set_result({
                         "Client-Integrity": client_integrity,
-                        "Client-Version": client_version
+                        "Client-Version": client_version,
+                        "X-Device-Id": device_id
                     })
             await route.continue_()
         except Exception:


### PR DESCRIPTION
## Summary
- Load `Client-Integrity`, `Client-Version`, and `X-Device-Id` headers from `accounts.json` or `headers.json` with warnings when missing
- Only include headers that are available when creating the HTTP session
- Capture `X-Device-Id` in the header harvesting helper

## Testing
- `python -m py_compile core.py get_headers.py main.py setup_campaigns.py`

------
https://chatgpt.com/codex/tasks/task_e_68aefd70e848832e9b486b28138abbc9